### PR TITLE
build: Create bazel-eclipse/ directory if it does not yet exist

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -14,6 +14,10 @@ gulp.task('build-plugin', (done) => {
     }
   });
 
+  if (!fs.existsSync(bazelEclipseDir)) {
+    fs.mkdirSync(bazelEclipseDir);
+  }
+
   // del.sync(bazelEclipseDir + '/**', { force: true });
   fs.rmdirSync(bazelEclipseDir, {recursive: true});
 


### PR DESCRIPTION
This fixes #23.

@guw 